### PR TITLE
fix panic in parse logic

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -92,11 +92,12 @@ func getMetadata(obj map[string]interface{}) map[string]interface{} {
 
 func toRole(rawRole map[string]interface{}) Role {
 	rules := []Rule{}
-	rawRules := rawRole["rules"].([]interface{})
-	for _, r := range rawRules {
-		rules = append(rules, toRule(r))
+	if rawRole["rules"] != nil {
+		rawRules := rawRole["rules"].([]interface{})
+		for _, r := range rawRules {
+			rules = append(rules, toRule(r))
+		}
 	}
-
 	return Role{
 		getNamespacedName(getMetadata(rawRole)),
 		rules,


### PR DESCRIPTION
The following panic is happening when running rback on OpenShift 4.4:
```
kubectl get sa,roles,rolebindings,clusterroles,clusterrolebindings --all-namespaces -o json | rback > result.dot
panic: interface conversion: interface {} is nil, not []interface {}

goroutine 1 [running]:
main.toRole(0xc0001b9470, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/Users/hausenbl/go/src/github.com/mhausenblas/rback/parse.go:95 +0x51a
main.(*Rback).parseRBAC(0xc0004d7ec8, 0x113f9c0, 0xc000098000, 0xc0000a20c0, 0x1)
	/Users/hausenbl/go/src/github.com/mhausenblas/rback/parse.go:56 +0x46d
main.main()
	/Users/hausenbl/go/src/github.com/mhausenblas/rback/main.go:45 +0xf6
```

After running with the change in this PR, the panic no longer occurs and I can generate the dot files.